### PR TITLE
Added Session creation API endpoints

### DIFF
--- a/user-api/devtools/docker-compose.yml
+++ b/user-api/devtools/docker-compose.yml
@@ -11,3 +11,9 @@ services:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: dev
       POSTGRES_DB: com3014db
+
+  redis:
+    image: redis:7.2-alpine
+    ports:
+      - target: 6379
+        published: 23456

--- a/user-api/pom.xml
+++ b/user-api/pom.xml
@@ -64,6 +64,10 @@
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-actuator</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-data-redis</artifactId>
+    </dependency>
   </dependencies>
 
   <build>

--- a/user-api/src/main/java/uk/ac/surrey/com3014/jg01314/session/AuthenticationException.java
+++ b/user-api/src/main/java/uk/ac/surrey/com3014/jg01314/session/AuthenticationException.java
@@ -1,0 +1,9 @@
+package uk.ac.surrey.com3014.jg01314.session;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.UNAUTHORIZED)
+public class AuthenticationException extends RuntimeException {
+
+}

--- a/user-api/src/main/java/uk/ac/surrey/com3014/jg01314/session/CreateSessionRequest.java
+++ b/user-api/src/main/java/uk/ac/surrey/com3014/jg01314/session/CreateSessionRequest.java
@@ -1,0 +1,5 @@
+package uk.ac.surrey.com3014.jg01314.session;
+
+public record CreateSessionRequest(String email, String password) {
+
+}

--- a/user-api/src/main/java/uk/ac/surrey/com3014/jg01314/session/Session.java
+++ b/user-api/src/main/java/uk/ac/surrey/com3014/jg01314/session/Session.java
@@ -1,0 +1,30 @@
+package uk.ac.surrey.com3014.jg01314.session;
+
+import jakarta.persistence.Id;
+import java.io.Serializable;
+import org.springframework.data.redis.core.RedisHash;
+import org.springframework.data.redis.core.index.Indexed;
+
+@RedisHash(value = "Session", timeToLive = 86_400L)
+class Session implements Serializable {
+
+  @Id
+  @Indexed
+  private final String id;
+
+  @Indexed
+  private final Integer userId;
+
+  Session(String id, Integer userId) {
+    this.id = id;
+    this.userId = userId;
+  }
+
+  String getId() {
+    return id;
+  }
+
+  Integer getUserId() {
+    return userId;
+  }
+}

--- a/user-api/src/main/java/uk/ac/surrey/com3014/jg01314/session/SessionController.java
+++ b/user-api/src/main/java/uk/ac/surrey/com3014/jg01314/session/SessionController.java
@@ -1,0 +1,43 @@
+package uk.ac.surrey.com3014.jg01314.session;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletResponse;
+import java.net.URI;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import uk.ac.surrey.com3014.jg01314.user.UserService;
+
+@RestController
+@RequestMapping("/api/session")
+class SessionController {
+
+  private final UserService userService;
+  private final SessionService sessionService;
+
+  @Autowired
+  SessionController(UserService userService, SessionService sessionService) {
+    this.userService = userService;
+    this.sessionService = sessionService;
+  }
+
+  @PostMapping
+  ResponseEntity<Void> createSession(@RequestBody CreateSessionRequest request,
+                                                      HttpServletResponse response) {
+    var user = userService.findByEmail(request.email())
+        .filter(foundUser -> userService.verifyPassword(foundUser, request.password()))
+        .orElseThrow(AuthenticationException::new);
+
+    var session = sessionService.createSession(user);
+    var sessionIdCookie = new Cookie("SessionID", session.getId());
+    sessionIdCookie.setHttpOnly(true);
+    sessionIdCookie.setSecure(true);
+    response.addCookie(sessionIdCookie);
+
+    return ResponseEntity.created(URI.create("/api/session")).build();
+  }
+
+}

--- a/user-api/src/main/java/uk/ac/surrey/com3014/jg01314/session/SessionIdGenerator.java
+++ b/user-api/src/main/java/uk/ac/surrey/com3014/jg01314/session/SessionIdGenerator.java
@@ -1,0 +1,25 @@
+package uk.ac.surrey.com3014.jg01314.session;
+
+import java.util.Random;
+
+class SessionIdGenerator {
+
+  private static final char[] SESSION_ID_CHARACTERS =
+      "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ".toCharArray();
+  private static final int SESSION_ID_CHARACTERS_LENGTH = SESSION_ID_CHARACTERS.length;
+  private static final int SESSION_ID_LENGTH = 72;
+  private static final Random RANDOM = new Random();
+
+  private SessionIdGenerator() {
+  }
+
+  static String generateSessionId() {
+    var sessionIdCharArray = new char[SESSION_ID_LENGTH];
+
+    for (int i = 0; i < SESSION_ID_LENGTH; i++) {
+      sessionIdCharArray[i] = SESSION_ID_CHARACTERS[RANDOM.nextInt(SESSION_ID_CHARACTERS_LENGTH)];
+    }
+
+    return new String(sessionIdCharArray);
+  }
+}

--- a/user-api/src/main/java/uk/ac/surrey/com3014/jg01314/session/SessionRepository.java
+++ b/user-api/src/main/java/uk/ac/surrey/com3014/jg01314/session/SessionRepository.java
@@ -1,0 +1,10 @@
+package uk.ac.surrey.com3014.jg01314.session;
+
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.lang.NonNull;
+
+interface SessionRepository extends CrudRepository<Session, String> {
+
+  boolean existsById(@NonNull String id);
+
+}

--- a/user-api/src/main/java/uk/ac/surrey/com3014/jg01314/session/SessionService.java
+++ b/user-api/src/main/java/uk/ac/surrey/com3014/jg01314/session/SessionService.java
@@ -1,0 +1,22 @@
+package uk.ac.surrey.com3014.jg01314.session;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import uk.ac.surrey.com3014.jg01314.user.User;
+
+@Service
+class SessionService {
+
+  private final SessionRepository sessionRepository;
+
+  @Autowired
+  SessionService(SessionRepository sessionRepository) {
+    this.sessionRepository = sessionRepository;
+  }
+
+  Session createSession(User user) {
+    var session = new Session(SessionIdGenerator.generateSessionId(), user.getId());
+    return sessionRepository.save(session);
+  }
+
+}

--- a/user-api/src/main/java/uk/ac/surrey/com3014/jg01314/user/User.java
+++ b/user-api/src/main/java/uk/ac/surrey/com3014/jg01314/user/User.java
@@ -23,7 +23,7 @@ public class User {
   public User() {
   }
 
-  User(String username, String email, String passwordHash) {
+  public User(String username, String email, String passwordHash) {
     this.username = username;
     this.email = email;
     this.passwordHash = passwordHash;

--- a/user-api/src/main/java/uk/ac/surrey/com3014/jg01314/user/UserRepository.java
+++ b/user-api/src/main/java/uk/ac/surrey/com3014/jg01314/user/UserRepository.java
@@ -1,9 +1,12 @@
 package uk.ac.surrey.com3014.jg01314.user;
 
+import java.util.Optional;
 import org.springframework.data.repository.CrudRepository;
 
 interface UserRepository extends CrudRepository<User, Integer> {
 
   boolean existsByEmail(String email);
+
+  Optional<User> findByEmail(String email);
 
 }

--- a/user-api/src/main/java/uk/ac/surrey/com3014/jg01314/user/UserService.java
+++ b/user-api/src/main/java/uk/ac/surrey/com3014/jg01314/user/UserService.java
@@ -1,5 +1,6 @@
 package uk.ac.surrey.com3014.jg01314.user;
 
+import java.util.Optional;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -11,7 +12,7 @@ public class UserService {
   private final PasswordEncoder passwordEncoder;
 
   @Autowired
-  public UserService(UserRepository userRepository, PasswordEncoder passwordEncoder) {
+  UserService(UserRepository userRepository, PasswordEncoder passwordEncoder) {
     this.userRepository = userRepository;
     this.passwordEncoder = passwordEncoder;
   }
@@ -21,5 +22,13 @@ public class UserService {
     var user = new User(username, email, hashedPassword);
 
     return userRepository.save(user);
+  }
+
+  public Optional<User> findByEmail(String email) {
+    return userRepository.findByEmail(email);
+  }
+
+  public boolean verifyPassword(User user, String password) {
+    return passwordEncoder.matches(password, user.getPasswordHash());
   }
 }

--- a/user-api/src/main/resources/config/application-development.properties
+++ b/user-api/src/main/resources/config/application-development.properties
@@ -2,3 +2,8 @@
 spring.datasource.url=jdbc:postgresql://localhost:12345/com3014db
 spring.datasource.username=postgres
 spring.datasource.password=dev
+
+# Redis
+spring.data.redis.host=localhost
+spring.data.redis.port=23456
+spring.data.redis.password=

--- a/user-api/src/main/resources/config/application.properties
+++ b/user-api/src/main/resources/config/application.properties
@@ -2,3 +2,9 @@
 spring.datasource.url=${DB_URL}
 spring.datasource.username=${DB_USERNAME}
 spring.datasource.password=${DB_PASSWORD}
+
+# Redis
+
+spring.data.redis.host=${REDIS_HOST}
+spring.data.redis.port=${REDIS_PORT}
+spring.data.redis.password=${REDIS_PASSWORD}

--- a/user-api/src/test/java/uk/ac/surrey/com3014/jg01314/AbstractIntegrationTest.java
+++ b/user-api/src/test/java/uk/ac/surrey/com3014/jg01314/AbstractIntegrationTest.java
@@ -12,14 +12,17 @@ import org.springframework.context.ApplicationContextInitializer;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
+import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
 
 /**
  * Helper class which starts up the entire app, but allows parts of it to be mocked for better
  * integration testing
  */
+@SuppressWarnings("resource")
 @Testcontainers
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @ContextConfiguration(initializers = {AbstractIntegrationTest.Initializer.class})
@@ -28,13 +31,16 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 @DirtiesContext
 public abstract class AbstractIntegrationTest {
 
-  @SuppressWarnings("resource")
   @Container
   private static final PostgreSQLContainer<?> POSTGRE_SQL_CONTAINER =
       new PostgreSQLContainer<>("postgres:latest")
           .withDatabaseName("integration_test_db")
           .withUsername("test_username")
           .withPassword("test");
+
+  @Container
+  private static final GenericContainer<?> REDIS_CONTAINER =
+      new GenericContainer<>(DockerImageName.parse("redis:7.2-alpine")).withExposedPorts(6379);
 
   @Autowired
   protected EntityManager entityManager;
@@ -49,7 +55,10 @@ public abstract class AbstractIntegrationTest {
       TestPropertyValues.of(
           "spring.datasource.url=" + POSTGRE_SQL_CONTAINER.getJdbcUrl(),
           "spring.datasource.username=" + POSTGRE_SQL_CONTAINER.getUsername(),
-          "spring.datasource.password=" + POSTGRE_SQL_CONTAINER.getPassword()
+          "spring.datasource.password=" + POSTGRE_SQL_CONTAINER.getPassword(),
+          "spring.data.redis.host=" + REDIS_CONTAINER.getHost(),
+          "spring.data.redis.port=" + REDIS_CONTAINER.getMappedPort(6379),
+          "spring.data.redis.password="
       ).applyTo(configurableApplicationContext.getEnvironment());
     }
   }

--- a/user-api/src/test/java/uk/ac/surrey/com3014/jg01314/session/SessionControllerTest.java
+++ b/user-api/src/test/java/uk/ac/surrey/com3014/jg01314/session/SessionControllerTest.java
@@ -1,0 +1,72 @@
+package uk.ac.surrey.com3014.jg01314.session;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import uk.ac.surrey.com3014.jg01314.AbstractIntegrationTest;
+import uk.ac.surrey.com3014.jg01314.user.User;
+import uk.ac.surrey.com3014.jg01314.user.UserService;
+import uk.ac.surrey.com3014.jg01314.user.UserTestUtil;
+
+@ExtendWith(MockitoExtension.class)
+class SessionControllerTest extends AbstractIntegrationTest {
+
+  @MockBean
+  private UserService userService;
+
+  @MockBean
+  private SessionService sessionService;
+
+  private final User user = UserTestUtil.userWithId();
+
+  @Test
+  void createSession_WhenNotFound_AssertUnauthorized() {
+    when(userService.findByEmail(user.getEmail())).thenReturn(Optional.empty());
+
+    var request = new CreateSessionRequest("nonexistantemail@test.com", "password");
+    var response = testRestTemplate.postForEntity("/api/session", request, Void.class);
+
+    verify(sessionService, never()).createSession(any());
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+  }
+
+  @Test
+  void createSession_WhenIncorrectPassword_AssertUnauthorized() {
+    var incorrectPassword = "incorrectPassword";
+
+    when(userService.findByEmail(user.getEmail())).thenReturn(Optional.of(user));
+    when(userService.verifyPassword(user, incorrectPassword)).thenReturn(false);
+
+    var request = new CreateSessionRequest(user.getEmail(), incorrectPassword);
+    var response = testRestTemplate.postForEntity("/api/session", request, Void.class);
+
+    verify(sessionService, never()).createSession(any());
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+  }
+
+  @Test
+  void createSession_WhenCorrect_AssertOk() {
+    var createdSession = new Session("some_session_id", user.getId());
+
+    when(userService.findByEmail(user.getEmail())).thenReturn(Optional.of(user));
+    when(userService.verifyPassword(user, UserTestUtil.PASSWORD)).thenReturn(true);
+    when(sessionService.createSession(user)).thenReturn(createdSession);
+
+    var request = new CreateSessionRequest(user.getEmail(), UserTestUtil.PASSWORD);
+    var response = testRestTemplate.postForEntity("/api/session", request, Void.class);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+    assertThat(response.getHeaders().get(HttpHeaders.SET_COOKIE))
+        .contains("SessionID=" + createdSession.getId() + "; Secure; HttpOnly");
+  }
+}

--- a/user-api/src/test/java/uk/ac/surrey/com3014/jg01314/session/SessionIdGeneratorTest.java
+++ b/user-api/src/test/java/uk/ac/surrey/com3014/jg01314/session/SessionIdGeneratorTest.java
@@ -1,0 +1,32 @@
+package uk.ac.surrey.com3014.jg01314.session;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+
+import java.util.HashSet;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+@ExtendWith(SpringExtension.class)
+class SessionIdGeneratorTest {
+
+  @Test
+  void generateSessionId() {
+    var sessionId = SessionIdGenerator.generateSessionId();
+
+    assertThat(sessionId).hasSize(72);
+  }
+
+  @Test
+  void generateSessionId_AssertUnique() {
+    var keySet = new HashSet<String>();
+
+    for (int i = 0; i < 10000; i++) {
+      var key = SessionIdGenerator.generateSessionId();
+      if (!keySet.add(key)) {
+        fail("Found duplicate key: " + key);
+      }
+    }
+  }
+}

--- a/user-api/src/test/java/uk/ac/surrey/com3014/jg01314/session/SessionServiceTest.java
+++ b/user-api/src/test/java/uk/ac/surrey/com3014/jg01314/session/SessionServiceTest.java
@@ -1,0 +1,48 @@
+package uk.ac.surrey.com3014.jg01314.session;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.ac.surrey.com3014.jg01314.user.User;
+import uk.ac.surrey.com3014.jg01314.user.UserTestUtil;
+
+@ExtendWith(MockitoExtension.class)
+class SessionServiceTest {
+
+  @Mock
+  private SessionRepository sessionRepository;
+
+  @InjectMocks
+  private SessionService sessionService;
+
+  @Captor
+  private ArgumentCaptor<String> sessionIdCaptor;
+
+  @Captor
+  private ArgumentCaptor<Session> sessionCaptor;
+
+  private final User user = UserTestUtil.userWithId();
+
+  @Test
+  void createSession() {
+    sessionService.createSession(user);
+
+    verify(sessionRepository).save(sessionCaptor.capture());
+
+    var savedSession = sessionCaptor.getValue();
+
+    assertThat(savedSession)
+        .extracting(Session::getUserId)
+        .isEqualTo(user.getId());
+    assertThat(savedSession)
+        .extracting(Session::getId)
+        .isNotNull();
+  }
+}

--- a/user-api/src/test/java/uk/ac/surrey/com3014/jg01314/user/UserTestUtil.java
+++ b/user-api/src/test/java/uk/ac/surrey/com3014/jg01314/user/UserTestUtil.java
@@ -1,0 +1,26 @@
+package uk.ac.surrey.com3014.jg01314.user;
+
+import java.util.Random;
+import org.testcontainers.shaded.org.apache.commons.lang3.reflect.FieldUtils;
+
+public class UserTestUtil {
+
+  public static final String USERNAME = "John";
+  public static final String EMAIL = "jsmith123@example.com";
+  public static final String PASSWORD = "Password123";
+  private static final Random RANDOM = new Random();
+
+  private UserTestUtil() {
+  }
+
+  public static User userWithId() {
+    var user = new User(USERNAME, EMAIL, PASSWORD);
+    try {
+      FieldUtils.writeField(user, "id", RANDOM.nextInt(), true);
+    } catch (IllegalAccessException e) {
+      throw new RuntimeException(e);
+    }
+    return user;
+  }
+
+}


### PR DESCRIPTION
Added Session creation endpoint, expected request format:

```
{
    "email": "some.email@example.com",
    "password": "password123"
}
```

Will return a 401 Unauthorized if the email or password was incorrect
Will return a 200 OK if the email and password authenticated successfully, and set a `SessionID` cookie to the expected value