### PR TITLE
Fixed migration

### DIFF
--- a/recipe-api/src/main/resources/db/migration/V1__Create_recipes_table.sql
+++ b/recipe-api/src/main/resources/db/migration/V1__Create_recipes_table.sql
@@ -1,9 +1,9 @@
 CREATE TABLE recipes (
-    id INT PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
-    name CHAR(60)            NOT NULL,
-    ingredients VARCHAR(300) NOT NULL,
-    difficulty CHAR(15)      NOT NULL,
-    dietary_restrictions CHAR(50)
+    id                   INT PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
+    name                 TEXT NOT NULL,
+    ingredients          TEXT NOT NULL,
+    difficulty           TEXT NOT NULL,
+    dietary_restrictions TEXT
 );
 
 INSERT INTO recipes (name, ingredients, difficulty, dietary_restrictions)


### PR DESCRIPTION
Fixed migration that was adding spaces to meet the fixed-length char(N) columns. Just replaced them with TEXT, since the performance is the same and we won't need to adjust the max length.

@amaark you'll need to delete your database container and re-run the compose to get this to work.